### PR TITLE
Prepare ring_buffer v0.2.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,11 +11,6 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
-set(RING_BUFFER_TOP_LEVEL OFF)
-if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
-  set(RING_BUFFER_TOP_LEVEL ON)
-endif()
-
 add_library(ring_buffer INTERFACE)
 target_include_directories(
   ring_buffer INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -23,26 +18,6 @@ target_include_directories(
 
 option(RING_BUFFER_BUILD_BENCHMARKS "Build benchmarks" OFF)
 option(RING_BUFFER_BUILD_TESTS "Build tests" OFF)
-
-if(RING_BUFFER_TOP_LEVEL)
-  if(DEFINED ENABLE_BENCHMARKS)
-    message(
-      DEPRECATION
-        "ENABLE_BENCHMARKS is deprecated; use RING_BUFFER_BUILD_BENCHMARKS instead.")
-    set(RING_BUFFER_BUILD_BENCHMARKS
-        "${ENABLE_BENCHMARKS}"
-        CACHE BOOL "Build benchmarks" FORCE)
-  endif()
-
-  if(DEFINED ENABLE_TESTS)
-    message(
-      DEPRECATION
-        "ENABLE_TESTS is deprecated; use RING_BUFFER_BUILD_TESTS instead.")
-    set(RING_BUFFER_BUILD_TESTS
-        "${ENABLE_TESTS}"
-        CACHE BOOL "Build tests" FORCE)
-  endif()
-endif()
 
 if(RING_BUFFER_BUILD_BENCHMARKS)
   message(STATUS "Benchmarks enabled")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.15)
 
 project(
   ring_buffer
-  VERSION 0.1.1
+  VERSION 0.2.0
   LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ include(FetchContent)
 FetchContent_Declare(
   ring_buffer
   GIT_REPOSITORY https://github.com/HuRuilizhen/ring_buffer.git
-  GIT_TAG        v0.1.1
+  GIT_TAG        v0.2.0
 )
 
 FetchContent_MakeAvailable(ring_buffer)

--- a/README.md
+++ b/README.md
@@ -21,10 +21,6 @@ integration via CMake's `find_package` or `FetchContent`.
 - (Optional) A CMake version recent enough to support presets for the
   recommended development workflow
 
-`ENABLE_TESTS` and `ENABLE_BENCHMARKS` are deprecated compatibility aliases
-for top-level builds. Prefer the prefixed options below so embedded builds do
-not collide with parent projects.
-
 ## Table of Contents
 
 - [ring\_buffer](#ring_buffer)
@@ -74,11 +70,6 @@ cmake -S . -B build \
   -DRING_BUFFER_BUILD_TESTS=ON \
   -DRING_BUFFER_BUILD_BENCHMARKS=ON
 cmake --build build
-
-# Top-level compatibility aliases still work, but are deprecated
-cmake -S . -B build/compat \
-  -DENABLE_TESTS=ON \
-  -DENABLE_BENCHMARKS=ON
 
 # Install from a configured build tree
 sudo cmake --install build/release


### PR DESCRIPTION
## Summary
- remove legacy top-level CMake option aliases and keep only namespaced ring_buffer build options
- prepare the project version and FetchContent documentation for ring_buffer v0.2.0

## Verification
- cmake --preset debug
- ctest --preset debug
